### PR TITLE
Add new LSP diagnostic highlight for neovim 0.6.0

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -521,6 +521,10 @@ local function load_lsp()
     -- used for highlighting "write" references
     LspReferenceWrite = { style = "underline", sp = onenord.yellow },
 
+    DiagnosticError = { link = "LspDiagnosticsDefaultError" },
+    DiagnosticWarn = { link = "LspDiagnosticsDefaultWarning" },
+    DiagnosticInfo = { link = "LspDiagnosticsDefaultInformation" },
+    DiagnosticHint = { link = "LspDiagnosticsDefaultHint" },
     DiagnosticVirtualTextWarn = { link = "LspDiagnosticsVirtualTextWarning" },
     DiagnosticUnderlineWarn = { link = "LspDiagnosticsUnderlineWarning" },
     DiagnosticFloatingWarn = { link = "LspDiagnosticsFloatingWarning" },


### PR DESCRIPTION
https://github.com/neovim/neovim/commit/a5bbb932f9094098bd656d3f6be3c58344576709#diff-8df5fbf5803bbea8d9e9d4d8a63f0bac3a32e1925d74990a43c6327fad2aad03R28-R48
Neovim 0.6.0 introduced some new LSP diagnostic highlight groups. I see that we missed these 4

See also: `:help diagnostic-highlights`