### PR TITLE
Update tabline color

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -240,8 +240,8 @@ local function load_editor(config)
     -- tab pages line, where there are no labels
     TabLineFill = { fg = onenord.light_gray, bg = onenord.active },
     -- tab pages line, active tab page label
-    TablineSel = { fg = onenord.fg, bg = onenord.bg },
-    Tabline = { fg = onenord.fg, bg = onenord.bg },
+    TablineSel = { fg = onenord.cyan, bg = onenord.bg },
+    Tabline = { fg = onenord.light_gray, bg = onenord.active },
     -- titles for output from ":set all", ":autocmd" etc.
     Title = { fg = onenord.green, bg = onenord.none, style = "bold" },
     -- Visual mode selection


### PR DESCRIPTION
I use vim's tab, and cannot distinguish between active tab and inactive tab. I made a change, so it'll look like this
![image](https://user-images.githubusercontent.com/18320285/144373807-d1bc2ad7-99d5-4b5a-9e1a-468d30b3859b.png)

Feel free to change to any color you like (actually I want the background to be different too, but not sure which color to pick 😂 )