### PR TITLE
Make OneNord follow background option as it's set

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ require('onenord').setup({
 Here is an example of overwriting the default highlight groups and colors:
 
 ```lua
-local colors = require("onenord.colors")
+local colors = require("onenord.colors").load()
 
 require("onenord").setup({
   custom_highlights = {
@@ -116,7 +116,7 @@ require("onenord").setup({
 })
 ```
 
-You can also use the onenord color palette for other plugins using `local colors = require("onenord.colors")`!
+You can also use the onenord color palette for other plugins using `local colors = require("onenord.colors").load()`!
 
 ## Extras
 

--- a/doc/onenord.nvim.txt
+++ b/doc/onenord.nvim.txt
@@ -123,8 +123,8 @@ This is an example of the function with the default values:
 
 Here is an example of overwriting the default highlight groups and colors:
 >
-    local colors = require("onenord.colors")
-    
+    local colors = require("onenord.colors").load()
+
     require("onenord").setup({
       custom_highlights = {
         TSConstructor = { fg = colors.dark_blue },
@@ -135,7 +135,7 @@ Here is an example of overwriting the default highlight groups and colors:
     })
 <
 
-You can also use the onenord color palette for other plugins using `local colors = require("onenord.colors")`!
+You can also use the onenord color palette for other plugins using `local colors = require("onenord.colors").load()`!
 
 
 ================================================================================

--- a/lua/lualine/themes/onenord.lua
+++ b/lua/lualine/themes/onenord.lua
@@ -1,4 +1,4 @@
-local colors = require("onenord.colors")
+local colors = require("onenord.colors").load()
 
 local onenord = {}
 

--- a/lua/onenord/colors/init.lua
+++ b/lua/onenord/colors/init.lua
@@ -17,4 +17,4 @@ local function load()
   end
 end
 
-return load()
+return { load = load }

--- a/lua/onenord/init.lua
+++ b/lua/onenord/init.lua
@@ -14,7 +14,7 @@ function onenord.setup(options)
 end
 
 function onenord.load(exec_autocmd)
-  local colors = require("onenord.colors")
+  local colors = require("onenord.colors").load()
 
   util.load(colors, exec_autocmd)
 end


### PR DESCRIPTION
Before this change, the option was followed once
on initial load due to `require` behaviour.

Additionally, theme option is now respected
on repeated loads. E.g.:

```
:lua require('onenord').setup({theme = 'dark'})
:lua require('onenord').setup({theme = 'light'})
```

Yields a light variant, as you'd expect.

In order to unset forced theme, set it to `false`.
This is due to the fact that `{a = nil}` and `{}`
are equivalent. As such, providing `theme = nil`
is equivalent to not providing it at all.