### PR TITLE
feat: add highlight for nvim-treesitter-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Onenord is a Neovim theme written in Lua that combines the [Nord](https://www.no
 ### Plugin Support
 
 - [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+- [Treesitter Context](https://github.com/nvim-treesitter/nvim-treesitter-context)
 - [LSP Diagnostics](https://neovim.io/doc/user/lsp.html)
 - [Trouble](https://github.com/folke/trouble.nvim)
 - [Git Signs](https://github.com/lewis6991/gitsigns.nvim)

--- a/doc/onenord.nvim.txt
+++ b/doc/onenord.nvim.txt
@@ -28,6 +28,7 @@ Nord theme and provide a great programming experience by leveraging Treesitter!
 PLUGIN SUPPORT                                         *onenord-plugin_support*
 
 *   Treesitter (https://github.com/nvim-treesitter/nvim-treesitter)
+*   Treesitter Context (https://github.com/nvim-treesitter/nvim-treesitter-context)
 *   LSP Diagnostics (https://neovim.io/doc/user/lsp.html)
 *   Trouble (https://github.com/folke/trouble.nvim)
 *   Git Signs (https://github.com/lewis6991/gitsigns.nvim)

--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -675,6 +675,9 @@ function theme.highlights(colors, config)
       BufferLineIndicatorSelected = { fg = colors.yellow },
       BufferLineFill = { bg = colors.bg },
 
+      -- nvim-treesitter-context
+      TreesitterContext = { fg = colors.none, bg = colors.active },
+
       -- barbar
       BufferCurrent = { fg = colors.fg, bg = colors.bg },
       BufferCurrentIndex = { fg = colors.fg, bg = colors.bg },


### PR DESCRIPTION
Before:
![before_nord](https://user-images.githubusercontent.com/40792180/173184275-ebbf1486-1782-4303-abfe-45709b50cdbe.png)
 After:
![after_nord](https://user-images.githubusercontent.com/40792180/173184282-cbda3f3e-01d1-44ee-b953-54ba05558dd9.png)


I simply used the same highlights as `SignColumn`.