### PR TITLE
load function also uses 'custom_colors'

### DIFF
--- a/lua/onenord/colors/init.lua
+++ b/lua/onenord/colors/init.lua
@@ -10,11 +10,8 @@ local function load()
     theme = vim.o.background
   end
 
-  if theme == "light" then
-    return vim.tbl_deep_extend("force", light_colors, require("onenord.config").options.custom_colors)
-  else
-    return vim.tbl_deep_extend("force", dark_colors, require("onenord.config").options.custom_colors)
-  end
+  local base_colors = theme == "light" and light_colors or dark_colors
+  return vim.tbl_deep_extend("force", base_colors, require("onenord.config").options.custom_colors)
 end
 
 return { load = load }

--- a/lua/onenord/colors/init.lua
+++ b/lua/onenord/colors/init.lua
@@ -11,9 +11,9 @@ local function load()
   end
 
   if theme == "light" then
-    return light_colors
+    return vim.tbl_deep_extend("force", light_colors, require("onenord.config").options.custom_colors)
   else
-    return dark_colors
+    return vim.tbl_deep_extend("force", dark_colors, require("onenord.config").options.custom_colors)
   end
 end
 


### PR DESCRIPTION
Hello!!

I noticed that the color palette that can be retrieved with `require("onenord.colors").load()` is not using the colors set in `custom_colors`.

If this was the correct behavior originally, sorry...

This is my favorite color theme. I use it all the time!