### PR TITLE
feat: make markdown headings distinguishable with treesitter

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -454,6 +454,20 @@ function theme.highlights(colors, config)
       -- Variable names defined by the language: `this` or `self` in Javascript.
       ["@variable.builtin"] = { fg = colors.red, style = config.styles.variables },
 
+      -- Specific to Markdown: different levels of headings
+      ["@markup.heading.1.markdown"] = { link = "markdownH1" },
+      ["@markup.heading.2.markdown"] = { link = "markdownH2" },
+      ["@markup.heading.3.markdown"] = { link = "markdownH3" },
+      ["@markup.heading.4.markdown"] = { link = "markdownH4" },
+      ["@markup.heading.5.markdown"] = { link = "markdownH5" },
+      ["@markup.heading.6.markdown"] = { link = "markdownH6" },
+      ["@markup.heading.1.marker.markdown"] = { link = "markdownH1Delimiter" },
+      ["@markup.heading.2.marker.markdown"] = { link = "markdownH2Delimiter" },
+      ["@markup.heading.3.marker.markdown"] = { link = "markdownH3Delimiter" },
+      ["@markup.heading.4.marker.markdown"] = { link = "markdownH4Delimiter" },
+      ["@markup.heading.5.marker.markdown"] = { link = "markdownH5Delimiter" },
+      ["@markup.heading.6.marker.markdown"] = { link = "markdownH6Delimiter" },
+
       -- Legacy highlights
       ["@conditional"] = { link = "@keyword.conditional" },
       ["@exception"] = { link = "@keyword.exception" },


### PR DESCRIPTION
This pr simply defines the treesitter highlight groups `@markup.heading.*.markdown` and `@markup.heading.*.marker.markdown` to make different levels of markdown headings distinguishable when treesitter is enabled on markdown files.