### PR TITLE
Add Wezterm extras

### DIFF
--- a/extras/wezterm/onenord.toml
+++ b/extras/wezterm/onenord.toml
@@ -1,0 +1,66 @@
+# OneNord colorscheme for WezTerm terminal emulator.
+#
+# To use this theme, place this file in the .config/wezterm/colors folder
+# and load it inside of your .config/wezterm/wezterm.lua file with:
+#
+# config.color_scheme = "OneNord"
+#
+#
+# Please note that in order for the tab bar styling to be effective you
+# also need to have the following line in your config:
+#
+# config.use_fancy_tab_bar = false
+#
+
+[colors]
+background = "#2E3440"
+foreground = "#C8D0E0"
+cursor_bg = "#81A1C1"
+cursor_border = "#81A1C1"
+selection_bg = "#3F4758"
+ansi = [
+  "#3B4252",
+  "#BF616A",
+  "#A3BE8C",
+  "#EBCB8B",
+  "#81A1C1",
+  "#B988B0",
+  "#88C0D0",
+  "#E5E9F0",
+]
+brights = [
+  "#4C566A",
+  "#BF616A",
+  "#A3BE8C",
+  "#EBCB8B",
+  "#81A1C1",
+  "#B988B0",
+  "#8FBCBB",
+  "#ECEFF4",
+]
+
+[colors.tab_bar]
+background = "#2E3440"
+
+[colors.tab_bar.active_tab]
+bg_color = "#353B49"
+fg_color = "#88C0D0"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#2E3440"
+fg_color = "#C8D0E0"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#2E3440"
+fg_color = "#88C0D0"
+
+[colors.tab_bar.new_tab]
+bg_color = "#2E3440"
+fg_color = "#C8D0E0"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#2E3440"
+fg_color = "#88C0D0"
+
+[metadata]
+name = "OneNord"

--- a/extras/wezterm/onenord_light.toml
+++ b/extras/wezterm/onenord_light.toml
@@ -1,0 +1,66 @@
+# OneNord Light colorscheme for WezTerm terminal emulator.
+#
+# To use this theme, place this file in the .config/wezterm/colors folder
+# and load it inside of your .config/wezterm/wezterm.lua file with:
+#
+# config.color_scheme = "OneNord Light"
+#
+#
+# Please note that in order for the tab bar styling to be effective you
+# also need to have the following line in your config:
+#
+# config.use_fancy_tab_bar = false
+#
+
+[colors]
+background = "#F7F8FA"
+foreground = "#2E3440"
+cursor_bg = "#3879C5"
+cursor_border = "#3879C5"
+selection_bg = "#EAEBED"
+ansi = [
+  "#2E3440",
+  "#CB4F53",
+  "#48A53D",
+  "#EE5E25",
+  "#3879C5",
+  "#9F4ACA",
+  "#3EA1AD",
+  "#E5E9F0",
+]
+brights = [
+  "#646A76",
+  "#D16366",
+  "#5F9E9D",
+  "#BA793E",
+  "#1B40A6",
+  "#9665AF",
+  "#8FBCBB",
+  "#ECEFF4",
+]
+
+[colors.tab_bar]
+background = "#F7F8FA"
+
+[colors.tab_bar.active_tab]
+bg_color = "#DFE1E4"
+fg_color = "#3EA1AD"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#F7F8FA"
+fg_color = "#2E3440"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#F7F8FA"
+fg_color = "#3EA1AD"
+
+[colors.tab_bar.new_tab]
+bg_color = "#F7F8FA"
+fg_color = "#2E3440"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#F7F8FA"
+fg_color = "#3EA1AD"
+
+[metadata]
+name = "OneNord Light"


### PR DESCRIPTION
# Description
Add [Wezterm](https://github.com/wez/wezterm) extras 😃.

Please note that the tab bar styling requires having this in your `.config/wezterm/wezterm.lua`
```lua
config.use_fancy_tab_bar = false
```

## Screenshots

**Dark theme**
![Screenshot 2024-05-08 at 14 19 11](https://github.com/rmehri01/onenord.nvim/assets/97030518/969f9bcb-b616-48c1-b9fe-60cf06cf473d)

**Light theme**
![Screenshot 2024-05-08 at 14 15 22](https://github.com/rmehri01/onenord.nvim/assets/97030518/0a12e604-01d1-4bc1-a689-1d9bce663a84)
