### PR TITLE
docs: include custom_highlights style example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ local colors = require("onenord.colors").load()
 
 require("onenord").setup({
   custom_highlights = {
-    ["@constructor"] = { fg = colors.dark_blue },
+  ["@constructor"] = { fg = colors.dark_blue, style = 'bold' },
   },
   custom_colors = {
     red = "#ffffff",
@@ -134,7 +134,7 @@ local colors = require("onenord.colors").load()
 require("onenord").setup({
   custom_highlights = {
     light = {
-      ["@constructor"] = { fg = colors.dark_blue }, -- only applies in light theme
+      ["@constructor"] = { fg = colors.dark_blue, style = 'bold' }, -- only applies in light theme
     },
   },
   custom_colors = {

--- a/doc/onenord.nvim.txt
+++ b/doc/onenord.nvim.txt
@@ -137,7 +137,7 @@ Here is an example of overwriting the default highlight groups and colors:
 
     require("onenord").setup({
       custom_highlights = {
-        ["@constructor"] = { fg = colors.dark_blue },
+        ["@constructor"] = { fg = colors.dark_blue, style = 'bold' },
       },
       custom_colors = {
         red = "#ffffff",
@@ -152,7 +152,7 @@ If you use the `light` and `dark` keys, the override will be specific to those t
     require("onenord").setup({
       custom_highlights = {
         light = {
-          ["@constructor"] = { fg = colors.dark_blue }, -- only applies in light theme
+          ["@constructor"] = { fg = colors.dark_blue, style = 'bold' }, -- only applies in light theme
         },
       },
       custom_colors = {


### PR DESCRIPTION
Couldn't find documentation or an example on how to edit the style of custom_highlights. After searching found an example in #24.

Included a simple example on the existing documentation.