### PR TITLE
Avoid modifying BufferLineFill

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -827,7 +827,6 @@ function theme.highlights(colors, config)
 
       -- BufferLine
       BufferLineIndicatorSelected = { fg = colors.yellow },
-      BufferLineFill = { bg = colors.bg },
 
       -- nvim-treesitter-context
       TreesitterContext = { fg = colors.none, bg = colors.active },


### PR DESCRIPTION
Customizing BufferLineFill breaks the continuity between the separators and fill drawn by `bufferline.nvim`. I think it's best to simply avoid touching this highlight group, so here's a PR for if you're open to it.

* Current state
  ![Screenshot from 2024-12-18 19-17-40](https://github.com/user-attachments/assets/a8300e26-3933-4863-b045-a797e88fe11a)
* With this change
  ![Screenshot from 2024-12-18 19-12-52](https://github.com/user-attachments/assets/832eba08-ff25-424c-bcc5-348dbbe4dc8b)

An alternative fix would be to set all the bufferline groups required to maintain continuity, which I think can be inferred from https://github.com/akinsho/bufferline.nvim/blob/261a72b90d6db4ed8014f7bda976bcdc9dd7ce76/lua/bufferline/config.lua#L286-L620 ---you basically need to replace all occurrences of `separator_background_color`.