### PR TITLE
fix: Error with nil value related to `BufferLineFill` changes

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -943,7 +943,6 @@ function theme.highlights(colors, config)
 
     -- Disable nvim-tree background
     if config.disable.background then
-      remove_background(plugins.BufferLineFill)
       remove_background(plugins.NvimTreeNormal)
       remove_background(plugins.NeoTreeNormal)
       remove_background(plugins.NeoTreeNormalNC)


### PR DESCRIPTION
Hello! It has been a very long time! 😄

Actually, I got this error in my environment today...

<img width="653" alt="Screenshot 2024-12-20 at 12 31 01" src="https://github.com/user-attachments/assets/12f6db01-2eb1-4c69-bca0-3fe0642b4d84" />

For #90, perhaps the following code also needs to be removed.

```diff
     -- Disable nvim-tree background
     if config.disable.background then
-      remove_background(plugins.BufferLineFill)
       remove_background(plugins.NvimTreeNormal)
       remove_background(plugins.NeoTreeNormal)
       remove_background(plugins.NeoTreeNormalNC)
```

I would be happy if this is correct, but could you please confirm this for me?