### PR TITLE
add support for NeoTree tabs

### DIFF
--- a/lua/onenord/theme.lua
+++ b/lua/onenord/theme.lua
@@ -757,6 +757,10 @@ function theme.highlights(colors, config)
       NeoTreeNormalNC = { fg = colors.fg, bg = colors.active },
       NeoTreeSymbolicLinkTarget = { fg = colors.cyan, style = "bold" },
       NeoTreeCursorLine = { link = "Visual" },
+      NeoTreeTabActive = { fg = colors.fg, bg = colors.active, style = "bold" },
+      NeoTreeTabInactive = { fg = colors.light_gray, bg = colors.bg },
+      NeoTreeTabSeparatorActive = { fg = colors.yellow, bg = colors.active },
+      NeoTreeTabSeparatorInactive = { fg = colors.bg, bg = colors.bg },
 
       -- WhichKey
       WhichKey = { fg = colors.purple, style = "bold" },


### PR DESCRIPTION
Aims to keep the style consistent when using NeoTree tabs.

Before: ![Screenshot From 2025-04-16 10-29-05](https://github.com/user-attachments/assets/6aef1384-e791-41af-81ee-47fe4bd7a5ef) After: ![Screenshot From 2025-04-16 10-29-45](https://github.com/user-attachments/assets/77d575cf-5cf5-4d11-9dfe-c908cb013339)

Before: ![Screenshot From 2025-04-16 10-29-16](https://github.com/user-attachments/assets/eab34635-cd6f-47d8-9434-a6cae4ff7400) After: ![Screenshot From 2025-04-16 10-29-35](https://github.com/user-attachments/assets/8c70f439-cb06-4c61-8044-4a5d079a4977)
